### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
   "dependencies": {
     "bluebird": "^3.3.1",
     "machina": "^1.1.2",
-    "node-uuid": "^1.4.7",
     "object-hash": "^1.1.2",
     "postal": "^1.0.8",
     "rabbus": "^0.7.1",
+    "uuid": "^3.0.0",
     "wascally": "^0.2.10",
     "whistlepunk": "^0.3.3"
   },

--- a/src/bus.js
+++ b/src/bus.js
@@ -13,7 +13,7 @@ const filter = require('./filter');
 
 var fs = Promise.promisifyAll(require("fs"));
 
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 function exit(){
     logger.warn("");

--- a/src/process/index.js
+++ b/src/process/index.js
@@ -2,7 +2,7 @@
 
 var filter = require('../filter');
 var logger = require("../logging")("bus-process");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 const processNS = "process";
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.